### PR TITLE
change gradle version, set child view clickable as intended

### DIFF
--- a/app/src/main/java/example/dbhat/com/expandablelistviewwithcheckbox/ExpListViewAdapterWithCheckbox.java
+++ b/app/src/main/java/example/dbhat/com/expandablelistviewwithcheckbox/ExpListViewAdapterWithCheckbox.java
@@ -249,7 +249,7 @@ public class ExpListViewAdapterWithCheckbox extends BaseExpandableListAdapter {
 
     @Override
     public boolean isChildSelectable(int groupPosition, int childPosition) {
-        return false;
+        return true;
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This was a great example, but child view click event was not working.

So I changed child view as clickable,
and now the testers can see what you implemented on the click event.